### PR TITLE
feat PersonDeatilVC 에서 스크롤로 감독이나 배우 이름이 가려질때 Navigation 타이틀에 보여지는 기능

### DIFF
--- a/MovieReviewApp/ViewController/MovieDetailViewController.swift
+++ b/MovieReviewApp/ViewController/MovieDetailViewController.swift
@@ -126,7 +126,6 @@ class MovieDetailViewController: UIViewController, UIGestureRecognizerDelegate {
         }
         let navigationAppearance = navibar.standardAppearance
         if offset > 1 {
-            navigationItem.title = detailViewModel.getMovie()?.title
             let backgroundColor = UIColor(red: 1, green: 1, blue: 1, alpha: 1)
             navibar.tintColor = .black
             navibar.titleTextAttributes = [.foregroundColor: UIColor.black]

--- a/MovieReviewApp/ViewController/PersonDetailViewController.swift
+++ b/MovieReviewApp/ViewController/PersonDetailViewController.swift
@@ -73,6 +73,12 @@ class PersonDetailViewController: UIViewController {
     var collectionViewHeightAnchor: NSLayoutConstraint?
     var collectionViewOriginSize: CGFloat?
     var likeCount: Int = 0
+    var titleView: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17, weight: .regular)
+        label.textColor = .label
+        return label
+    }()
     
     override func viewDidLoad() {
                 
@@ -96,11 +102,9 @@ class PersonDetailViewController: UIViewController {
         
         profileViewSubviewsSetting()
         
-        guard let name = name else { return }
         guard let personId = personId else { return }
         
         navigationController.navigationBar.topItem?.title = ""
-        navigationItem.title = ""
         navigationController.navigationBar.scrollEdgeAppearance?.backgroundColor = .white
         
         scrollView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
@@ -266,10 +270,6 @@ class PersonDetailViewController: UIViewController {
         movieDetailVC.modalPresentationStyle = .fullScreen
         navigationController?.pushViewController(movieDetailVC, animated: true)
     }
-    
-    func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
-        print(scrollView.contentOffset.y)
-    }
 }
 
 extension PersonDetailViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
@@ -292,12 +292,14 @@ extension PersonDetailViewController: UICollectionViewDelegate, UICollectionView
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == self.scrollView {
-            print(scrollView.contentOffset.y)
+            let offsetY = scrollView.contentOffset.y
+            navigationItem.title = offsetY > -30.0 ? name : ""
+            navigationController?.navigationBar.setNeedsLayout()
             return
         }
         let count = mediaFilterView.stackViewButtonCount()
         mediaFilterView.barLeadingAnchor?.constant = scrollView.contentOffset.x / CGFloat(count)
-        print(personMovieCollectionView.indexPathsForVisibleItems)
+
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {


### PR DESCRIPTION
- 감독 배우 디테일 화면에서 네비게이션 타이틀 alpha 값이 0으로 변경되는 버그가 존재함
- 타이틀을 변경후에 navigationController?.navigationBar.setNeedsLayout() 으로 해결
- https://developer.apple.com/forums/thread/713424 => ios16 의 버그인걸로 생각이됨