### PR TITLE
bug CellMoveStackView 버튼 클릭으로 스크롤이 안되는 문제 해결

### DIFF
--- a/MovieReviewApp/View/CellMoveStackView.swift
+++ b/MovieReviewApp/View/CellMoveStackView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class CellMoveStackView: UIStackView {
     
-    var collectionView: UICollectionView
+    weak var collectionView: UICollectionView?
     private var buttonTextFont: UIFont = UIFont.systemFont(ofSize: 20, weight: .medium)
     private let bar: UIView = {
         let bar = UIView()
@@ -97,11 +97,15 @@ class CellMoveStackView: UIStackView {
     }
     
     @objc func cellMove(senderBtn: UIButton) {
+        guard let collectionView = collectionView else {
+            print("CellMoveStackView collectionview is nil")
+            return }
         for index in 0..<self.arrangedSubviews.count {
             if let btn = self.arrangedSubviews[index] as? UIButton {
                 btn.isSelected = false
                 if btn == senderBtn {
-                    collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .bottom, animated: true)
+                    guard let rect = collectionView.layoutAttributesForItem(at:IndexPath(row: index, section: 0))?.frame else { return }
+                    collectionView.scrollRectToVisible(rect, animated: true)
                 }
             }
         }

--- a/MovieReviewApp/ViewController/MyStorageViewController.swift
+++ b/MovieReviewApp/ViewController/MyStorageViewController.swift
@@ -132,11 +132,13 @@ extension MyStorageViewController: UICollectionViewDelegate, UICollectionViewDat
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        print("didscroll")
         let count = cellMoveStackView.stackViewButtonCount()
         cellMoveStackView.barLeadingAnchor?.constant = scrollView.contentOffset.x / CGFloat(count)
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        print("didend")
         let index = storageCollectionView.indexPathsForVisibleItems[0].item
         cellMoveStackView.setButtonTitleColor(index: index)
     }


### PR DESCRIPTION
- CellMoveStackView의 scrollToItem을 -> scrollRectToVisible로 변경
- 특정 버전부터 scrollToItem이 안되는 걸로 보임