### PR TITLE
bug collectionview 왼쪽이나 오른쪽 끝에서 스크롤시 CellMoveStackView 글자색이 현재 위치에 맞지…

### DIFF
--- a/MovieReviewApp/ViewController/MyStorageViewController.swift
+++ b/MovieReviewApp/ViewController/MyStorageViewController.swift
@@ -27,7 +27,6 @@ class MyStorageViewController: UIViewController {
         let layout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = 0
-        layout.minimumLineSpacing = 0
         layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         let cv: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         cv.isPagingEnabled = true
@@ -132,14 +131,15 @@ extension MyStorageViewController: UICollectionViewDelegate, UICollectionViewDat
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        print("didscroll")
         let count = cellMoveStackView.stackViewButtonCount()
         cellMoveStackView.barLeadingAnchor?.constant = scrollView.contentOffset.x / CGFloat(count)
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        print("didend")
-        let index = storageCollectionView.indexPathsForVisibleItems[0].item
+        guard let index = storageCollectionView.indexPathForItem(at: scrollView.contentOffset)?.item else {
+            print("StorageCollectionView IndexPathForItem is nil")
+            return
+        }
         cellMoveStackView.setButtonTitleColor(index: index)
     }
     

--- a/MovieReviewApp/ViewController/RatingViewController.swift
+++ b/MovieReviewApp/ViewController/RatingViewController.swift
@@ -140,7 +140,10 @@ class RatingViewController: UIViewController, UICollectionViewDataSource,  UICol
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        let index = collectionView.indexPathsForVisibleItems[0].item
+        guard let index = collectionView.indexPathForItem(at: scrollView.contentOffset)?.item else {
+            print("StorageCollectionView IndexPathForItem is nil")
+            return
+        }
         cellMoveStackView.setButtonTitleColor(index: index)
     }
     


### PR DESCRIPTION
… 않는 위치로 가있는 문제 해결

- indexPathsForVisibleItems 의 문제. 약간의 스크롤시 다른 cell까지 보이기 때문에 문제가 되었음
- indexPathsForVisibleItems를 indexPathForItem(at: scrollView.contentOffset)로 해결